### PR TITLE
Fix date column type in lab_8.2

### DIFF
--- a/deep-dive/08-query-acceleration/lab_8.2.sql
+++ b/deep-dive/08-query-acceleration/lab_8.2.sql
@@ -1,6 +1,6 @@
 -- Step 1
 CREATE TABLE uk_averages_by_day (
-    day LowCardinality(String),
+    day Date,
     average_price UInt32
 )
 ENGINE = MergeTree
@@ -11,10 +11,10 @@ REFRESH EVERY 12 HOURS
 TO uk_averages_by_day
 AS
     SELECT
-        toYYYYMMDD(date) AS day,
+        toDate(date) AS day,
         avg(price) AS average_price
     FROM uk_prices_3
-    WHERE toYear(date) >= '2025'
+    WHERE toYear(date) >= 2025
     GROUP BY day;
 
 -- Step 2

--- a/realtime-analytics/08-query-acceleration/lab_8.2.sql
+++ b/realtime-analytics/08-query-acceleration/lab_8.2.sql
@@ -1,6 +1,6 @@
 -- Step 1
 CREATE TABLE uk_averages_by_day (
-    day LowCardinality(String),
+    day Date,
     average_price UInt32
 )
 ENGINE = MergeTree
@@ -11,10 +11,10 @@ REFRESH EVERY 12 HOURS
 TO uk_averages_by_day
 AS
     SELECT
-        toYYYYMMDD(date) AS day,
+        toDate(date) AS day,
         avg(price) AS average_price
     FROM uk_prices_3
-    WHERE toYear(date) >= '2025'
+    WHERE toYear(date) >= 2025
     GROUP BY day;
 
 -- Step 2


### PR DESCRIPTION
The `day` column in `uk_averages_by_day` was typed `LowCardinality(String)` while holding a date value.

- `day LowCardinality(String)` → `day Date`
- `toYYYYMMDD(date)` → `toDate(date)` — returns a `Date` rather than a `UInt32` like `20250115`, matching the new column type
- `toYear(date) >= '2025'` → `>= 2025` — numeric comparison, avoiding an implicit string conversion

Applied to both the `deep-dive/` and `realtime-analytics/` copies of the lab, which were identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)